### PR TITLE
Update to readme, remove unused constant, tweak link flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,12 +273,6 @@ BMP format in uncompressed RGB
 
 DDS format in DXT1 or DXT5
 
-#### Cube Maps
-
-    [constant] dds-cubemap-face-order
-
-The face order a DDS cubemap. Set to `EWUDNS`. In order to reorder this you will need to redefine `SOIL_DDS_CUBEMAP_FACE_ORDER` in `SOIL.h`.
-
 #### Internal HDR Representations
 
     [constant] fake-hdr/rgbe

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Alex Charlton (alex.n.charlton@gmail.com)
 
 ## Version history
 
+- 1.3: Remove `dds-cubemap-face-order`, fix texture creation function return values, support OpenGL ES
 - 1.2: SOIL source built into egg
 - 1.1: Added procedures to retrieve texture size
 - 1.0: First release

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The source is available on [GitHub](https://github.com/dleslie/soil-egg)
 
 The interface adheres closely to the stock SOIL interface.
 
+soil is known to work on Linux, Mac OS X, Windows, and with OpenGL ES. soil will automatically compile with ES support on ARM hardware, or when `gles` is defined during compilation (e.g. `chicken-install -D gles`).
+
 Much thanks to Jonathan Dummer for writing the original SOIL library.
 
 ## SOIL Overview

--- a/README.md
+++ b/README.md
@@ -1,347 +1,321 @@
 [[tags: egg soil image opengl gl bmp tga dds png jpg game]]
 
-== soil
-
-SOIL bindings for Chicken.
+# soil
 
 [[toc:]]
 
-== Disclaimer
+[SOIL](http://www.lonesock.net/soil.html) bindings for Chicken.
 
-For now, the egg is available at:
-https://github.com/dleslie/soil-egg
+The source is available on [GitHub](https://github.com/dleslie/soil-egg)
 
 The interface adheres closely to the stock SOIL interface.
 
 Much thanks to Jonathan Dummer for writing the original SOIL library.
 
-== SOIL Overview
+## SOIL Overview
 
-SOIL is a tiny c library for uploading images as textures into OpenGL.  Also saving and loading of images is supported.
+[SOIL](http://www.lonesock.net/soil.html) is a tiny C library for uploading images as textures into OpenGL. Also, saving and loading of images is supported.
 
-It uses Sean's Tool Box image loader as a base:
-http://www.nothings.org/
+SOIL uses [Sean's Tool Box](http://www.nothings.org/) image loader as a base, upgrading it to load TGA and DDS files, and adds a direct path for loading DDS files straight into OpenGL textures, when applicable.
 
-SOIL upgrades stb_image to load TGA and DDS files, and adds a direct path for loading DDS files straight into OpenGL textures, when applicable.
+The following image formats are supported:
 
-Image Formats:
-; BMP : load and save
-; TGA : load and save
-; DDS : load and save
-; PNG : load
-; JPG : load
+- BMP: load and save
+- TGA: load and save
+- DDS: load and save
+- PNG: load
+- JPG: load
 
 OpenGL Texture Features:
-* resample to power-of-two sizes
-* MIPmap generation
-* compressed texture S3TC formats (if supported)
-* can pre-multiply alpha for you, for better compositing
-* can flip image about the y-axis (except pre-compressed DDS files)
 
-Thanks to:
-* Sean Barret - for the awesome stb_image
-* Dan Venkitachalam - for finding some non-compliant DDS files, and patching some explicit casts
-* everybody at gamedev.net
-* Jonathan Dummer for writing SOIL
+- resample to power-of-two sizes
+- MIPmap generation
+- compressed texture S3TC formats (if supported)
+- can pre-multiply alpha for you, for better compositing
+- can flip image about the y-axis (except pre-compressed DDS files)
 
-== Reference
+## Reference
 
-=== Flags and Enumerations
+### Functions
 
-==== Image Loading
-
-The format of images that may be loaded.
-
-<constant>force-channels/auto</constant>
-
-Leaves the image in whatever format it was found.
-
-<constant>force-channels/luminous</constant>
-
-Forces the image to load as Luminous (greyscale).
-
-<constant>force-channels/luminous-alpha</constant>
-
-Forces the image to load as Luminous with Alpha.
-
-<constant>force-channels/rgb</constant>
-
-Forces the image to load as Red Green Blue.
-
-<constant>force-channels/rgba</constant>
-
-Forces the image to load as Red Green Blue Alpha.
-
-==== Texture Creation
-
-<constant>texture-id/create-new-id</constant>
-
-Passed in as reuse-texture-id, and will cause SOIL to register a new texture ID using glGenTextures(). If the value passed into reuse-texture-id > 0 then SOIL will just reuse that texture ID (great for reloading image assets in-game).
-
-==== OpenGL Texture Format
-
-<constant>texture/power-of-two</constant>
-
-Force the image to be power-of-two.
-
-<constant>texture/mipmaps</constant>
-
-Generate mipmaps for the texture.
-
-<constant>texture/repeats</constant>
-
-Sets the image to repeating, otherwise it will be clamped.
-
-<constant>texture/multiply-alpha</constant>
-
-For when using (GL_ONE, GL_ONE_MINUS_SRC_ALPHA) blending.
-
-<constant>texture/invert-y</constant>
-
-Flip the image vertically.
-
-<constant>texture/compress</constant>
-
-If the card supports it this will convert RGB to DXT1, and RGBA to DXT5.
-
-<constant>texture/dds-direct</constant>
-
-Will load DDS files directly without any additional processing.
-
-<constant>texture/ntsc-safe-rgb</constant>
-
-Clamps RGB components to the NTSC GL safe range.
-
-<constant>texture/cogo-y</constant>
-
-RGB becomes CoYCg and RGBA becomes CoCgAY.
-
-<constant>texture/rectangle</constant>
-
-Uses ARB_texture_rectangle; generates pixedl indexed with no repeat, mip maps or cube maps.
-
-==== Saving File Formats
-
-<constant>save-type/tga</constant>
-
-TGA format in uncompressed RGBA or RGB.
-
-<constant>save-type/bmp</constant>
-
-BMP format in uncompressed RGB
-
-<constant>save-type/dds</constant>
-
-DDS format in DXT1 or DXT5
-
-==== Cube Maps
-
-<constant>dds-cubemap-face-order</constant>
-
-The current face order as defined in the C preprocessor. Defaults to EWUDNS. In order to reorder this you will need to define SOIL_DDS_CUBEMAP_FACE_ORDER in the C preprocessor, likely in the #> <# header block of the appropriate scheme source file.
-
-==== Internal HDR Representations
-
-<constant>fake-hdr/rgbe</constant>
-
-RGB * pow( 2.0, A - 128.0)
-
-<constant>fake-hdr/rgb-div-alpha</constant>
-
-RGB / A
-
-<constant>fake-hdr/rgb-div-alpha-squared</constant>
-
-RGB / (A * A)
-
-=== Functions
-
-<procedure>(load-ogl-texture filename force-channels texture-id texture-flags)</procedure>
+    [procedure] (load-ogl-texture filename force-channels texture-id texture-flags)
 
 Loads an image from disk into an OpenGL texture.
 
-<parameter>filename</parameter> Name of the file to load
-<parameter>force-channels</parameter> Format of image channels to force, see above definitions for appropriate values
-<parameter>texture-id</parameter> Use either texture-id/create-new-id or use an existing texture id to overwrite an existing texture
-<parameter>texture-flags</parameter> See above for appropriate texture/* to use, ie, texture/repeats or texture/mipmaps. Flags are bitwise, and can be combined with bitwise-ior
+- `filename`: Name of the file to load
+- `force-channels`: Format of image channels to force, see below definitions for appropriate values
+- `texture-id`: Use either `texture-id/create-new-id` or use an existing texture id to overwrite an existing texture
+- `texture-flags`: See below for appropriate `texture/***` flags to use, i.e., `texture/repeats` or `texture/mipmaps`. Flags are bitwise, and can be combined with `bitwise-ior`
 
-Returns an OpenGL texture-id.
+Returns an OpenGL texture ID.
 
-<procedure>(load-ogl-cubemap xpos-file xneg-file ypos-file yneg-file zpos-file zneg-file force-channels texture-id texture-flags)</procedure>
+    [procedure] (load-ogl-cubemap xpos-file xneg-file ypos-file yneg-file zpos-file zneg-file force-channels texture-id texture-flags)
 
 Loads a cubemap texture from disc.
 
-<parameter>xpos-file</parameter> File to load for the +x cube face
-<parameter>xneg-file</parameter> File to load for the -x cube face
-<parameter>ypos-file</parameter> File to load for the +y cube face
-<parameter>yneg-file</parameter> File to load for the -y cube face
-<parameter>zpos-file</parameter> File to load for the +z cube face
-<parameter>zneg-file</parameter> File to load for the -z cube face
-<parameter>force-channels</parameter> Format of image channels to force, see above definitions for appropriate values
-<parameter>texture-id</parameter> Use either texture-id/create-new-id or use an existing texture id to overwrite an existing texture
-<parameter>texture-flags</parameter> See above for appropriate texture/* to use, ie, texture/repeats or texture/mipmaps. Flags are bitwise, and can be combined with bitwise-ior
+- `xpos-file`: File to load for the +x cube face
+- `xneg-file`: File to load for the -x cube face
+- `ypos-file`: File to load for the +y cube face
+- `yneg-file`: File to load for the -y cube face
+- `zpos-file`: File to load for the +z cube face
+- `zneg-file`: File to load for the -z cube face
+- `force-channels`: Format of image channels to force, see below definitions for appropriate values
+- `texture-id`: Use either `texture-id/create-new-id` or use an existing texture id to overwrite an existing texture
+- `texture-flags`: See below for appropriate `texture/***` flags to use, i.e., `texture/repeats` or `texture/mipmaps`. Flags are bitwise, and can be combined with `bitwise-ior`
 
-Returns an OpenGL texture-id.
+Returns an OpenGL texture ID.
 
-<procedure>(load-ogl-single-cubemap filename face-order force-channels texture-id texture-flags)</procedure>
+    [procedure] (load-ogl-single-cubemap filename face-order force-channels texture-id texture-flags)
 
 Loads a single image from disc and splits it into an OpenGL cubemap texture.
 
-<parameter>filename</parameter> File to load and split into the texture
-<parameter>face-order</parameter> The order of the faces in the file, any combination of NSWEUD
-<parameter>force-channels</parameter> Format of image channels to force, see above definitions for appropriate values
-<parameter>texture-id</parameter> Use either texture-id/create-new-id or use an existing texture id to overwrite an existing texture
-<parameter>texture-flags</parameter> See above for appropriate texture/* to use, ie, texture/repeats or texture/mipmaps. Flags are bitwise, and can be combined with bitwise-ior
+- `filename`: File to load and split into the texture
+- `face-order`: The order of the faces in the file, any permutation of `"NSWEUD"` representing North, South, West, East, Up, Down
+- `force-channels`: Format of image channels to force, see below definitions for appropriate values
+- `texture-id`: Use either `texture-id/create-new-id` or use an existing texture id to overwrite an existing texture
+- `texture-flags`: See below for appropriate `texture/***` flags to use, i.e., `texture/repeats` or `texture/mipmaps`. Flags are bitwise, and can be combined with `bitwise-ior`
 
-Returns an OpenGL texture-id.
+Returns an OpenGL texture ID.
 
-<procedure>(load-ogl-hdr-texture filename hdr-format rescale-to-max texture-id texture-flags)</procedure>
+    [procedure] (load-ogl-hdr-texture filename hdr-format rescale-to-max texture-id texture-flags)
 
 Loads an HDR image from disk into an OpenGL texture.
 
-<parameter>filename</parameter> File to load and split into the texture
-<parameter>hdr-format</parameter> One of the fake-hdr/* flags, IE, fake-hdr/rgbe
-<parameter>rescale-to-max</parameter> If true, rescales the image to max
-<parameter>texture-id</parameter> Use either texture-id/create-new-id or use an existing texture id to overwrite an existing texture
-<parameter>texture-flags</parameter> See above for appropriate texture/* to use, ie, texture/repeats or texture/mipmaps. Flags are bitwise, and can be combined with bitwise-ior
+- `filename`: File to load and split into the texture
+- `hdr-format`: One of the `fake-hdr/***` flags, i.e., `fake-hdr/rgbe`
+- `rescale-to-max`: If true, rescales the image to max
+- `texture-id`: Use either `texture-id/create-new-id` or use an existing texture id to overwrite an existing texture
+- `texture-flags`: See below for appropriate `texture/***` flags to use, i.e., `texture/repeats` or `texture/mipmaps`. Flags are bitwise, and can be combined with `bitwise-ior`
 
-Returns an OpenGL texture-id.
+Returns an OpenGL texture ID.
 
-<procedure>(load-ogl-texture-from-memory buffer length force-channels texture-id texture-flags)</procedure>
+    [procedure] (load-ogl-texture-from-memory buffer length force-channels texture-id texture-flags)
 
 Loads an image from memory into an OpenGL texture.
 
-<parameter>buffer</parameter> The blob from which the image should be loaded
-<parameter>length</parameter> The length, in bytes, to read from the blob
-<parameter>force-channels</parameter> Format of image channels to force, see above definitions for appropriate values
-<parameter>texture-id</parameter> Use either texture-id/create-new-id or use an existing texture id to overwrite an existing texture
-<parameter>texture-flags</parameter> See above for appropriate texture/* to use, ie, texture/repeats or texture/mipmaps. Flags are bitwise, and can be combined with bitwise-ior
+- `buffer`: The blob from which the image should be loaded
+- `length`: The length, in bytes, to read from the blob
+- `force-channels`: Format of image channels to force, see below definitions for appropriate values
+- `texture-id`: Use either `texture-id/create-new-id` or use an existing texture id to overwrite an existing texture
+- `texture-flags`: See below for appropriate `texture/***` flags to use, i.e., `texture/repeats` or `texture/mipmaps`. Flags are bitwise, and can be combined with `bitwise-ior`
 
-Returns an OpenGL texture-id.
+Returns an OpenGL texture ID.
 
-<procedure>(load-ogl-cubemap-from-memory xpos-buffer xpos-length xneg-buffer xneg-length ypos-buffer ypos-length yneg-buffer yneg-length zpos-buffer zpos-length zneg-buffer zneg-length force-channels texture-id texture-flags)</procedure>
+    [procedure] (load-ogl-cubemap-from-memory xpos-buffer xpos-length xneg-buffer xneg-length ypos-buffer ypos-length yneg-buffer yneg-length zpos-buffer zpos-length zneg-buffer zneg-length force-channels texture-id texture-flags)
 
 Loads a cubemap texture from memory.
 
-<parameter>xpos-buffer</parameter> Buffer to load for the +x cube face
-<parameter>xpos-length</parameter> Size, in bytes, to read from xpos-buffer
-<parameter>xneg-buffer</parameter> Buffer to load for the -x cube face
-<parameter>xneg-length</parameter> Size, in bytes, to read from xneg-buffer
-<parameter>ypos-buffer</parameter> Buffer to load for the +y cube face
-<parameter>ypos-length</parameter> Size, in bytes, to read from ypos-buffer
-<parameter>yneg-buffer</parameter> Buffer to load for the -y cube face
-<parameter>yneg-length</parameter> Size, in bytes, to read from yneg-buffer
-<parameter>zpos-buffer</parameter> Buffer to load for the +z cube face
-<parameter>zpos-length</parameter> Size, in bytes, to read from zpos-buffer
-<parameter>zneg-buffer</parameter> Buffer to load for the -z cube face
-<parameter>zneg-length</parameter> Size, in bytes, to read from zneg-buffer
-<parameter>force-channels</parameter> Format of image channels to force, see above definitions for appropriate values
-<parameter>texture-id</parameter> Use either texture-id/create-new-id or use an existing texture id to overwrite an existing texture
-<parameter>texture-flags</parameter> See above for appropriate texture/* to use, ie, texture/repeats or texture/mipmaps. Flags are bitwise, and can be combined with bitwise-ior
+- `xpos-buffer`: Buffer to load for the +x cube face
+- `xpos-length`: Size, in bytes, to read from xpos-buffer
+- `xneg-buffer`: Buffer to load for the -x cube face
+- `xneg-length`: Size, in bytes, to read from xneg-buffer
+- `ypos-buffer`: Buffer to load for the +y cube face
+- `ypos-length`: Size, in bytes, to read from ypos-buffer
+- `yneg-buffer`: Buffer to load for the -y cube face
+- `yneg-length`: Size, in bytes, to read from yneg-buffer
+- `zpos-buffer`: Buffer to load for the +z cube face
+- `zpos-length`: Size, in bytes, to read from zpos-buffer
+- `zneg-buffer`: Buffer to load for the -z cube face
+- `zneg-length`: Size, in bytes, to read from zneg-buffer
+- `force-channels`: Format of image channels to force, see below definitions for appropriate values
+- `texture-id`: Use either `texture-id/create-new-id` or use an existing texture id to overwrite an existing texture
+- `texture-flags`: See below for appropriate `texture/***` flags to use, i.e., `texture/repeats` or `texture/mipmaps`. Flags are bitwise, and can be combined with `bitwise-ior`
 
-Returns an OpenGL texture-id.
+Returns an OpenGL texture ID.
 
-<procedure>(load-ogl-single-cubemap-from-memory buffer length order force-channels texture-id texture-flags)</procedure>
+    [procedure] (load-ogl-single-cubemap-from-memory buffer length order force-channels texture-id texture-flags)
 
 Loads a single image from memory and splits it into an OpenGL cubemap texture.
 
-<parameter>buffer</parameter> Blob to load and split into the texture
-<parameter>length</parameter> Size, in bytes, to read from the blob
-<parameter>face-order</parameter> The order of the faces in the file, any combination of NSWEUD
-<parameter>force-channels</parameter> Format of image channels to force, see above definitions for appropriate values
-<parameter>texture-id</parameter> Use either texture-id/create-new-id or use an existing texture id to overwrite an existing texture
-<parameter>texture-flags</parameter> See above for appropriate texture/* to use, ie, texture/repeats or texture/mipmaps. Flags are bitwise, and can be combined with bitwise-ior
+- `buffer`: Blob to load and split into the texture
+- `length`: Size, in bytes, to read from the blob
+- `face-order`: The order of the faces in the file, any permutation of `"NSWEUD"` representing North, South, West, East, Up, Down
+- `force-channels`: Format of image channels to force, see below definitions for appropriate values
+- `texture-id`: Use either `texture-id/create-new-id` or use an existing texture id to overwrite an existing texture
+- `texture-flags`: See below for appropriate `texture/***` flags to use, i.e., `texture/repeats` or `texture/mipmaps`. Flags are bitwise, and can be combined with `bitwise-ior`
 
-Returns an OpenGL texture-id.
+Returns an OpenGL texture ID.
 
-<procedure>(create-ogl-texture data width height force-channels texture-id texture-flags)</procedure>
+    [procedure] (create-ogl-texture data width height force-channels texture-id texture-flags)
 
 Creates a 2D OpenGL texture from raw image data. The raw data is not freed after being uploaded. (And it is thus safe to use a blob).
 
-<parameter>data</parameter> Blob to upload as an OpenGL texture
-<parameter>width</parameter> The width of the image in pixels
-<parameter>height</parameter> The height of the image in pixels
-<parameter>force-channels</parameter> Format of image channels to force, see above definitions for appropriate values
-<parameter>texture-id</parameter> Use either texture-id/create-new-id or use an existing texture id to overwrite an existing texture
-<parameter>texture-flags</parameter> See above for appropriate texture/* to use, ie, texture/repeats or texture/mipmaps. Flags are bitwise, and can be combined with bitwise-ior
+- `data`: Blob to upload as an OpenGL texture
+- `width`: The width of the image in pixels
+- `height`: The height of the image in pixels
+- `force-channels`: Format of image channels to force, see below definitions for appropriate values
+- `texture-id`: Use either `texture-id/create-new-id` or use an existing texture id to overwrite an existing texture
+- `texture-flags`: See below for appropriate `texture/***` flags to use, i.e., `texture/repeats` or `texture/mipmaps`. Flags are bitwise, and can be combined with `bitwise-ior`
 
-Returns an OpenGL texture-id.
+Returns an OpenGL texture ID.
 
-<procedure>(create-ogl-single-cubemap data width height force-channels order texture-id texture-flags)</procedure>
+    [procedure] (create-ogl-single-cubemap data width height force-channels order texture-id texture-flags)
 
-<parameter>data</parameter> Blob to upload as an OpenGL texture
-<parameter>width</parameter> The width of the image in pixels
-<parameter>height</parameter> The height of the image in pixels
-<parameter>face-order</parameter> The order of the faces in the file, any combination of NSWEUD
-<parameter>force-channels</parameter> Format of image channels to force, see above definitions for appropriate values
-<parameter>texture-id</parameter> Use either texture-id/create-new-id or use an existing texture id to overwrite an existing texture
-<parameter>texture-flags</parameter> See above for appropriate texture/* to use, ie, texture/repeats or texture/mipmaps. Flags are bitwise, and can be combined with bitwise-ior
+- `data`: Blob to upload as an OpenGL texture
+- `width`: The width of the image in pixels
+- `height`: The height of the image in pixels
+- `face-order`: The order of the faces in the file, any permutation of `"NSWEUD"` representing North, South, West, East, Up, Down
+- `force-channels`: Format of image channels to force, see below definitions for appropriate values
+- `texture-id`: Use either `texture-id/create-new-id` or use an existing texture id to overwrite an existing texture
+- `texture-flags`: See below for appropriate `texture/***` flags to use, i.e., `texture/repeats` or `texture/mipmaps`. Flags are bitwise, and can be combined with `bitwise-ior`
 
-Returns an OpenGL texture-id.
+Returns an OpenGL texture ID.
 
-<procedure>(save-screenshot filename save-type x y width height)</procedure>
+    [procedure] (save-screenshot filename save-type x y width height)
 
 Captures the OpenGL window (RGB) and saves it to disk.
 
-<parameter>filename</parameter> The file to save the image to
-<parameter>save-type</parameter> The format to save the image in, one of save-type/*
-<parameter>x</parameter> Start x position
-<parameter>y</parameter> Start y position
-<parameter>width</parameter> Width of image
-<parameter>height</parameter> Height of image
+- `filename`: The file to save the image to
+- `save-type`: The format to save the image in, one of save-type/*
+- `x`: Start x position
+- `y`: Start y position
+- `width`: Width of image
+- `height`: Height of image
 
-Returns #t if succesful.
+Returns `#t` if successful.
 
-<procedure>(last-result)</procedure>
+    [procedure] (last-result)
 
 Returns the last error message as a string.
 
-<procedure>(ogl-texture-width texture)</procedure>
-<procedure>(ogl-texture-height texture)</procedure>
+    [procedure] (ogl-texture-width texture)
+    [procedure] (ogl-texture-height texture)
 
 Returns the width and height of the given OpenGL texture.
 
-== Known Issues
+
+### Flags and Enumerations
+
+#### Image Loading
+
+These flags affect the format of images that are loaded.
+
+    [constant] force-channels/auto
+
+Leaves the image in whatever format it was found.
+
+    [constant] force-channels/luminous
+
+Forces the image to load as Luminous (greyscale).
+
+    [constant] force-channels/luminous-alpha
+
+Forces the image to load as Luminous with Alpha.
+
+    [constant] force-channels/rgb
+
+Forces the image to load as Red Green Blue.
+
+    [constant] force-channels/rgba
+
+Forces the image to load as Red Green Blue Alpha.
+
+#### Texture Creation
+
+    [constant] texture-id/create-new-id
+
+Passed in as the `texture-id` argument, this will cause soil to register a new texture ID using `gl:gen-textures`. If the value passed as a `texture-id` argument is greater than zero, then soil will just reuse that texture ID (great for reloading image assets in-game).
+
+#### OpenGL Texture Format
+If multiple `texture/***` flags are to be passed to the `texture` argument, they must be OR’d (i.e. with `bitwise-ior`) together.
+
+    [constant] texture/power-of-two
+
+Force the image to be power-of-two.
+
+    [constant] texture/mipmaps
+
+Generate mipmaps for the texture.
+
+    [constant] texture/repeats
+
+Sets the image to repeating, otherwise it will be clamped.
+
+    [constant] texture/multiply-alpha
+
+For when using (`gl:+one+`, `gl:+one-minus-src-alpha+`) blending.
+
+    [constant] texture/invert-y
+
+Flip the image vertically.
+
+    [constant] texture/compress
+
+If the card supports it this will convert RGB to DXT1, and RGBA to DXT5.
+
+    [constant] texture/dds-direct
+
+Will load DDS files directly without any additional processing.
+
+    [constant] texture/ntsc-safe-rgb
+
+Clamps RGB components to the NTSC GL safe range.
+
+    [constant] texture/cogo-y
+
+RGB becomes CoYCg and RGBA becomes CoCgAY.
+
+    [constant] texture/rectangle
+
+Uses `ARB_texture_rectangle`; generates pixedl indexed with no repeat, mip maps or cube maps.
+
+#### Saving File Formats
+
+    [constant] save-type/tga
+
+TGA format in uncompressed RGBA or RGB.
+
+    [constant] save-type/bmp
+
+BMP format in uncompressed RGB
+
+    [constant] save-type/dds
+
+DDS format in DXT1 or DXT5
+
+#### Cube Maps
+
+    [constant] dds-cubemap-face-order
+
+The face order a DDS cubemap. Set to `EWUDNS`. In order to reorder this you will need to redefine `SOIL_DDS_CUBEMAP_FACE_ORDER` in `SOIL.h`.
+
+#### Internal HDR Representations
+
+    [constant] fake-hdr/rgbe
+
+RGB * pow( 2.0, A - 128.0)
+
+    [constant] fake-hdr/rgb-div-alpha
+
+RGB / A
+
+    [constant] fake-hdr/rgb-div-alpha-squared
+
+RGB / (A * A)
 
 
-== Authors
+## Authors
 
 Dan Leslie (dan@ironoxide.ca)
 
 Alex Charlton (alex.n.charlton@gmail.com)
 
-== Version history
+## Version history
 
-; 1.2 : SOIL source built into egg
+- 1.2: SOIL source built into egg
+- 1.1: Added procedures to retrieve texture size
+- 1.0: First release
 
-; 1.1 : Added procedures to retrieve texture size
-
-; 1.0 : First release
-
-== License
+## License
 
 Copyright 2012 Daniel J. Leslie. All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are
-permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
-   1. Redistributions of source code must retain the above copyright notice, this list of
-      conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 
-   2. Redistributions in binary form must reproduce the above copyright notice, this list
-      of conditions and the following disclaimer in the documentation and/or other materials
-      provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 
-THIS SOFTWARE IS PROVIDED BY DANIEL J. LESLIE ''AS IS'' AND ANY EXPRESS OR IMPLIED
-WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL DANIEL J. LESLIE OR
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY DANIEL J. LESLIE ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL DANIEL J. LESLIE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-The views and conclusions contained in the software and documentation are those of the
-authors and should not be interpreted as representing official policies, either expressed
-or implied, of Daniel J. Leslie.
+The views and conclusions contained in the software and documentation are those of the authors and should not be interpreted as representing official policies, either expressed or implied, of Daniel J. Leslie.

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Returns the last error message as a string.
 Returns the width and height of the given OpenGL texture.
 
 
-### Flags and Enumerations
+### Flags
 
 #### Image Loading
 

--- a/soil-src/SOIL.c
+++ b/soil-src/SOIL.c
@@ -1929,6 +1929,10 @@ int query_tex_rectangle_capability( void )
 
 int query_cubemap_capability( void )
 {
+  /* Modified by Alex Charlton: Query breaks OSX for some reason*/
+#if defined(__APPLE__) || defined(__APPLE_CC__)
+  has_cubemap_capability = SOIL_CAPABILITY_PRESENT;
+#else 
 	/*	check for the capability	*/
 	if( has_cubemap_capability == SOIL_CAPABILITY_UNKNOWN )
 	{
@@ -1950,6 +1954,7 @@ int query_cubemap_capability( void )
 		}
 	}
 	/*	let the user know if we can do cubemaps or not	*/
+#endif
 	return has_cubemap_capability;
 }
 

--- a/soil.release-info
+++ b/soil.release-info
@@ -1,5 +1,6 @@
 (repo git "git@github.com:dleslie/soil-egg.git")
 (uri targz "https://github.com/dleslie/soil-egg/tarball/{egg-release}")
+(release "1.3.0")
 (release "1.2.1")
 (release "1.2.0")
 (release "1.1.0")

--- a/soil.scm
+++ b/soil.scm
@@ -209,12 +209,3 @@ C_return(SOIL_save_image(f, t, width, height, c, data));
         (= 1 (save filename type (image-width soil-image) (image-height soil-image) (image-channels soil-image) (image-data soil-image))))))
 
   (define last-result (foreign-lambda c-string "SOIL_last_result")))
-
-
-
-
-
-
-
-
-

--- a/soil.scm
+++ b/soil.scm
@@ -9,7 +9,7 @@ typedef struct
 
 <#
 
-(module soil (force-channels/auto force-channels/luminous force-channels/luminous-alpha force-channels/rgb force-channels/rgba texture-id/create-new-id texture/power-of-two texture/mipmaps texture/repeats texture/multiply-alpha texture/invert-y texture/compress texture/dds-direct texture/ntsc-safe-rgb texture/cogo-y texture/rectangle save-type/tga save-type/bmp save-type/dds dds-cubemap-face-order fake-hdr/rgbe fake-hdr/rgb-div-alpha fake-hdr/rgb-div-alpha-squared load-ogl-texture load-ogl-cubemap load-ogl-single-cubemap load-ogl-hdr-texture load-ogl-texture-from-memory load-ogl-cubemap-from-memory load-ogl-single-cubemap-from-memory create-ogl-texture create-ogl-single-cubemap ogl-texture-width ogl-texture-height save-screenshot make-image image? image-data image-width image-height image-channels image-data-set! image-width-set! image-height-set! image-channels-set! load-image load-image-from-memory save-image last-result)
+(module soil (force-channels/auto force-channels/luminous force-channels/luminous-alpha force-channels/rgb force-channels/rgba texture-id/create-new-id texture/power-of-two texture/mipmaps texture/repeats texture/multiply-alpha texture/invert-y texture/compress texture/dds-direct texture/ntsc-safe-rgb texture/cogo-y texture/rectangle save-type/tga save-type/bmp save-type/dds fake-hdr/rgbe fake-hdr/rgb-div-alpha fake-hdr/rgb-div-alpha-squared load-ogl-texture load-ogl-cubemap load-ogl-single-cubemap load-ogl-hdr-texture load-ogl-texture-from-memory load-ogl-cubemap-from-memory load-ogl-single-cubemap-from-memory create-ogl-texture create-ogl-single-cubemap ogl-texture-width ogl-texture-height save-screenshot make-image image? image-data image-width image-height image-channels image-data-set! image-width-set! image-height-set! image-channels-set! load-image load-image-from-memory save-image last-result)
 
   (import chicken scheme foreign)
 
@@ -61,10 +61,6 @@ typedef struct
   (define save-type/tga SOIL_SAVE_TYPE_TGA)
   (define save-type/bmp SOIL_SAVE_TYPE_BMP)
   (define save-type/dds SOIL_SAVE_TYPE_DDS)
-
-  
-  (define-foreign-variable SOIL_DDS_CUBEMAP_FACE_ORDER c-string)
-  (define dds-cubemap-face-order SOIL_DDS_CUBEMAP_FACE_ORDER)
 
   (define-foreign-variable SOIL_HDR_RGBE unsigned-integer)
   (define-foreign-variable SOIL_HDR_RGBdivA unsigned-integer)

--- a/soil.setup
+++ b/soil.setup
@@ -6,7 +6,7 @@
 
 (define link-options
   (cond-expand
-    (macosx "-framework OpenGL -framework CoreServices")
+    (macosx "-framework OpenGL -framework CoreFoundation")
     (windows "-lopengl32")
     ((or gles arm) "-lGLESv2")
     (else "-lGL")))

--- a/soil.setup
+++ b/soil.setup
@@ -6,7 +6,7 @@
 
 (define link-options
   (cond-expand
-    (macosx "-framework OpenGL ")
+    (macosx "-framework OpenGL -framework CoreServices")
     (windows "-lopengl32")
     ((or gles arm) "-lGLESv2")
     (else "-lGL")))

--- a/soil.setup
+++ b/soil.setup
@@ -8,7 +8,8 @@
   (cond-expand
     (macosx "-framework OpenGL ")
     (windows "-lopengl32")
-    (else "-L/usr/X11R6/lib -L/usr/X11/lib -lGL -LX11")))
+    ((or gles arm) "-lGLESv2")
+    (else "-lGL")))
 
 (compile soil.scm ./soil-src/*.c -Isoil-src ,compile-options ,link-options -s -J -O3 -d0)
 (compile -s -O3 -d0 soil.import.scm)

--- a/soil.setup
+++ b/soil.setup
@@ -18,5 +18,5 @@
 (install-extension
  'soil
  '("soil.so" "soil.o" "soil.import.so")
- '((version 1.2.1)
+ '((version 1.3.0)
    (static "soil.o")))


### PR DESCRIPTION
Hi Dan,

Thanks for the kind words about Hypergiant :)

While documenting Hypergiant, I noticed that soil's docs needed some love, as they weren't getting recognized by Chickadee, and some of the formatting was off. Since the source's README.md was ostensibly a Markdown file, I took the liberty of converting it to be so (with creative licence while I was at it). I then converted the result to svnwiki markup with the markdown-svnwiki utility (which is `chicken-install`able). 

My documenting led me to realize that dds-cubemap-face-order (and the corresponding C define) is not actually used anywhere, and was hella awkward for use with CHICKEN, so I removed it from the egg's API. I also took the liberty of adding link options for OpenGL ES targets, and removing some (seemingly) extraneous links to X11.

I hope you don't mind this omnibus pull request. I modifed the setup and release info to be version 1.3.0, so all you'd need to do is tag the release. The wiki docs have already been updated.