### PR TITLE
Link with CoreFoundation on OSX

### DIFF
--- a/soil.setup
+++ b/soil.setup
@@ -6,7 +6,7 @@
 
 (define link-options
   (cond-expand
-    (macosx "-framework OpenGL ")
+    (macosx "-framework OpenGL -framework CoreFoundation")
     (windows "-lopengl32")
     (else "-L/usr/X11R6/lib -L/usr/X11/lib -lGL -LX11")))
 


### PR DESCRIPTION
This is a trivial patch that simply adds the CoreFoundation framework to the OSX compile flags.  Without this change, on OS X 10.9 one gets a slew of undefined symbol errors.