### PR TITLE
fix implicit declaration of glCompressedTexImage2D

### DIFF
--- a/soil-src/SOIL.c
+++ b/soil-src/SOIL.c
@@ -1768,7 +1768,7 @@ unsigned int SOIL_direct_load_DDS_from_memory(
 				} else
 				{
 					mip_size = ((w+3)/4)*((h+3)/4)*block_size;
-					gLCompressedTexImage2D(
+					glCompressedTexImage2D(
 						cf_target, i,
 						S3TC_type, w, h, 0,
 						mip_size, &DDS_data[byte_offset] );


### PR DESCRIPTION
Small typo fix. This was giving me an error on OS X 10.10:

soil-src/SOIL.c:1771:6: warning: implicit declaration of function 'gLCompressedTexImage2D' is invalid in C99 [-Wimplicit-function-declaration]
                                        gLCompressedTexImage2D(
                                        ^
1 warning generated.
Undefined symbols for architecture x86_64:
  "_gLCompressedTexImage2D", referenced from:
      _SOIL_direct_load_DDS_from_memory in SOIL.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)